### PR TITLE
Add `WXA_SKILL_DEBUG ` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ def introduction(request, responder):
     pass
 ```
 
+### Debugging
+
+To debug the server and turn off encryption/decryption, you can set the environment variable `WXA_SKILL_DEBUG` to be `True`.
+
 ### Command Line
 
 Installing the webex_assistant_sdk package adds a wxa_sdk command line application. Use the `-h` argument for help.

--- a/webex_assistant_sdk/app.py
+++ b/webex_assistant_sdk/app.py
@@ -11,12 +11,20 @@ class SkillApplication(Application):
     """
 
     def __init__(
-        self, import_name, *, secret, private_key, responder_class=SkillResponder, **kwargs
+        self,
+        import_name,
+        *,
+        secret,
+        private_key,
+        responder_class=SkillResponder,
+        use_encryption=True,
+        **kwargs,
     ):
 
         super().__init__(import_name, responder_class=responder_class, **kwargs)
         self.secret = secret
         self.private_key = private_key
+        self._use_encryption = use_encryption
 
     def introduce(self, handler=None):
         """Decorator for skill introduction states. If a skill is
@@ -37,7 +45,9 @@ class SkillApplication(Application):
 
     def lazy_init(self, nlp=None):
         Application.lazy_init(self, nlp)
-        self._server = create_skill_server(self.app_manager, self.secret, self.private_key)
+        self._server = create_skill_server(
+            self.app_manager, self.secret, self.private_key, use_encryption=self._use_encryption
+        )
 
     @property
     def web_app(self) -> Flask:

--- a/webex_assistant_sdk/app.py
+++ b/webex_assistant_sdk/app.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from mindmeld import Application
 
@@ -11,20 +13,13 @@ class SkillApplication(Application):
     """
 
     def __init__(
-        self,
-        import_name,
-        *,
-        secret,
-        private_key,
-        responder_class=SkillResponder,
-        use_encryption=True,
-        **kwargs,
+        self, import_name, *, secret, private_key, responder_class=SkillResponder, **kwargs
     ):
 
         super().__init__(import_name, responder_class=responder_class, **kwargs)
         self.secret = secret
         self.private_key = private_key
-        self._use_encryption = use_encryption
+        self._use_encryption = not os.environ.get('WXA_SKILL_DEBUG', False)
 
     def introduce(self, handler=None):
         """Decorator for skill introduction states. If a skill is

--- a/webex_assistant_sdk/app.py
+++ b/webex_assistant_sdk/app.py
@@ -1,5 +1,3 @@
-import os
-
 from flask import Flask
 from mindmeld import Application
 
@@ -19,7 +17,6 @@ class SkillApplication(Application):
         super().__init__(import_name, responder_class=responder_class, **kwargs)
         self.secret = secret
         self.private_key = private_key
-        self._use_encryption = not os.environ.get('WXA_SKILL_DEBUG', False)
 
     def introduce(self, handler=None):
         """Decorator for skill introduction states. If a skill is
@@ -40,9 +37,7 @@ class SkillApplication(Application):
 
     def lazy_init(self, nlp=None):
         Application.lazy_init(self, nlp)
-        self._server = create_skill_server(
-            self.app_manager, self.secret, self.private_key, use_encryption=self._use_encryption
-        )
+        self._server = create_skill_server(self.app_manager, self.secret, self.private_key)
 
     @property
     def web_app(self) -> Flask:

--- a/webex_assistant_sdk/server.py
+++ b/webex_assistant_sdk/server.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import time
 import uuid
 
@@ -23,10 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_skill_server(
-    app_manager: ApplicationManager,
-    secret: str,
-    private_key: RSAPrivateKey,
-    use_encryption: bool = True,
+    app_manager: ApplicationManager, secret: str, private_key: RSAPrivateKey
 ) -> Flask:
     server = Flask('mindmeld')
     CORS(server)
@@ -41,6 +39,7 @@ def create_skill_server(
         """The main endpoint for the MindMeld API"""
         start_time = time.time()
         try:
+            use_encryption = not os.environ.get('WXA_SKILL_DEBUG', False)
             if use_encryption:
                 request_json, challenge = validate_request(
                     secret, private_key, request.headers, request.get_data().decode('utf-8')

--- a/webex_assistant_sdk/server.py
+++ b/webex_assistant_sdk/server.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 def create_skill_server(
-    app_manager: ApplicationManager, secret: str, private_key: RSAPrivateKey
+    app_manager: ApplicationManager,
+    secret: str,
+    private_key: RSAPrivateKey,
+    use_encryption: bool = True,
 ) -> Flask:
     server = Flask('mindmeld')
     CORS(server)
@@ -38,9 +41,13 @@ def create_skill_server(
         """The main endpoint for the MindMeld API"""
         start_time = time.time()
         try:
-            request_json, challenge = validate_request(
-                secret, private_key, request.headers, request.get_data().decode('utf-8')
-            )
+            if use_encryption:
+                request_json, challenge = validate_request(
+                    secret, private_key, request.headers, request.get_data().decode('utf-8')
+                )
+            else:
+                request_json = json.loads(request.data)
+                challenge = None
         except SignatureValidationError as exc:
             raise BadMindMeldRequestError(exc.args[0], status_code=403)
         except (RequestValidationError, ServerChallengeValidationError) as exc:


### PR DESCRIPTION
~~Add the field `use_encryption` which is set to default as True. When `use_encryption` is set to False, we do not validate requests based on the key and secret.~~

Add an env variable `WXA_SKILL_DEBUG` which is set to be False by default. When it is set to be True, we turn off encryption/decryption and do not validate requests based on the key and the secret.

This is to help developers to debug their application servers.