### PR TITLE
Bug/handle string passwords

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version:

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -121,8 +121,16 @@ def test_generate_keys(temp_dir, password):
     public_key = temp_dir / 'key.id_rsa.pub'
 
     # Generate the keys
-    generate_keys(temp_dir / 'key.id_rsa', 'rsa', password)
+    generate_keys(private_key, 'rsa', password)
 
     # check if the files exist
     assert private_key.is_file()
     assert public_key.is_file()
+
+
+@pytest.mark.parametrize('password', [200, [1, 2, 3], {'foo': 'bar'}])
+def test_generate_keys_invalid_password(temp_dir, password):
+    private_key = temp_dir / 'key.id_rsa'
+
+    with pytest.raises(EncryptionKeyError):
+        generate_keys(private_key, 'rsa', password)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -29,10 +29,9 @@ KEYS = [
 ]
 
 
-@pytest.fixture(scope="session")
-def temp_dir(tmp_path_factory):
-    dir = tmp_path_factory.mktemp("tmp")
-    return dir
+@pytest.fixture(scope='session', name='temp_dir')
+def _temp_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("tmp")
 
 
 @pytest.mark.parametrize('key_type', KEYS)

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -114,7 +114,7 @@ def test_signatures():
         generate_signature(secret, '')
 
 
-@pytest.mark.parametrize('password', [None, b'bytes'])
+@pytest.mark.parametrize('password', [None, b'bytes', 'string'])
 def test_generate_keys(temp_dir, password):
     # Set expected file paths
     private_key = temp_dir / 'key.id_rsa'

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -12,6 +12,7 @@ from webex_assistant_sdk.crypto import (
     decrypt,
     encrypt,
     generate_signature,
+    generate_keys,
     get_file_contents,
     load_private_key,
     load_public_key,
@@ -26,6 +27,12 @@ KEYS = [
     # 'id_ed25519',
     # 'id_ed25519.encrypted',
 ]
+
+
+@pytest.fixture(scope="session")
+def temp_dir(tmp_path_factory):
+    dir = tmp_path_factory.mktemp("tmp")
+    return dir
 
 
 @pytest.mark.parametrize('key_type', KEYS)
@@ -105,3 +112,17 @@ def test_signatures():
 
     with pytest.raises(SignatureGenerationError):
         generate_signature(secret, '')
+
+
+@pytest.mark.parametrize('password', [None, b'bytes'])
+def test_generate_keys(temp_dir, password):
+    # Set expected file paths
+    private_key = temp_dir / 'key.id_rsa'
+    public_key = temp_dir / 'key.id_rsa.pub'
+
+    # Generate the keys
+    generate_keys(temp_dir / 'key.id_rsa', 'rsa', password)
+
+    # check if the files exist
+    assert private_key.is_file()
+    assert public_key.is_file()

--- a/webex_assistant_sdk/crypto.py
+++ b/webex_assistant_sdk/crypto.py
@@ -44,7 +44,7 @@ def encrypt(public_key, message: str) -> str:
 
 
 def decrypt(private_key, cipher_string: str) -> str:
-    """Decrypes a cypher using the given private key"""
+    """Decrypts a cypher using the given private key"""
     encrypted_components: Sequence[str] = cipher_string.split('.')
     encrypted_temp_key: str = encrypted_components[0]
     # only the first '.' character is special -- we should treat the remainder as the content
@@ -73,8 +73,10 @@ def decrypt(private_key, cipher_string: str) -> str:
 def load_private_key(data: bytes, password: Optional[str] = None):
     """Loads a private key in PEM format"""
     try:
+        if password:
+            password = _validate_password_input(password)
         private_key = serialization.load_pem_private_key(
-            data, password=_validate_password_input(password), backend=default_backend()
+            data, password=password, backend=default_backend()
         )
         return private_key
     except (binascii.Error, ValueError, UnsupportedAlgorithm) as ex:

--- a/webex_assistant_sdk/crypto.py
+++ b/webex_assistant_sdk/crypto.py
@@ -144,6 +144,8 @@ def generate_keys(filename: str, key_type: str, password: Optional[str] = None):
         private_key = ed25519.Ed25519PrivateKey.generate()
 
     if password:
+        if isinstance(password, str):
+            password = str.encode(password)
         encryption = serialization.BestAvailableEncryption(password)
     else:
         encryption = serialization.NoEncryption()


### PR DESCRIPTION
## What does this PR do?
Currently, there is a bug when calling `generate_keys` CLI command. If the user provides a password, the value is of type `str`, which causes an error to be thrown when passed into `serialization.BestAvailableEncryption()`. This PR adds validation checks to ensure that the correct type is provided. Additionally, some tests are added for this behavior.