### PR TITLE
feat: add support for assistant-event directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implemented `new` CLI command
+- Implemented `assistant-event` directive
 
 ### Changed
 

--- a/tests/test_responder.py
+++ b/tests/test_responder.py
@@ -105,3 +105,15 @@ def test_long_reply(responder: SkillResponder, query: str, remove_hyphens: bool,
     assert responder.directives[0]['type'] == 'view'
     assert responder.directives[1]['payload']['text'] == text
     assert responder.directives[1]['name'] == 'speak'
+
+def test_assistant_event(responder: SkillResponder):
+    expected_name = 'test'
+    expected_payload = { 'foo': 'bar' }
+
+    responder.send_assistant_event(expected_name, expected_payload)
+
+    directive = responder.directives[0]
+
+    assert directive['name'] == responder.DirectiveNames.ASSISTANT_EVENT
+    assert directive['payload']['name'] == expected_name
+    assert directive['payload']['payload'] == expected_payload

--- a/webex_assistant_sdk/dialogue.py
+++ b/webex_assistant_sdk/dialogue.py
@@ -24,6 +24,9 @@ class AssistantDirectiveNames(DirectiveNames):
     DISPLAY = 'display'
     """A generic display directive."""
 
+    ASSISTANT_EVENT = 'assistant-event'
+    """A directive to forward a generic payload"""
+
 
 class DirectiveNotSupportedError(Exception):
     pass
@@ -223,6 +226,18 @@ class SkillResponder(DialogueResponder):
         # If we sent neither long reply or speak, raise error.
         if not success:
             raise DirectiveNotSupportedError
+
+    def send_assistant_event(self, name, payload=None):
+        """Sends a 'assistant-event' directive
+
+        Args:
+            name (string): Used to identify the source of the event
+            payload (json object, optional): Payload to forward
+        """
+        self.act(self.DirectiveNames.ASSISTANT_EVENT, {
+            'name': name,
+            'payload': payload,
+        })
 
     @property
     def supported_directives(self):


### PR DESCRIPTION
Usage:
```
{
    "directives": [
        {
            "name": "assistant-event",
            "payload": {
                "name": "test",
                "payload": { "foo": "bar" },
            }
        }
    ]
}
```