### PR TITLE
Adds simple support for passing in NLP instances or DialogueManagers

### DIFF
--- a/webex_assistant_sdk/api/base.py
+++ b/webex_assistant_sdk/api/base.py
@@ -14,9 +14,12 @@ from .middlewares.signing import SignatureMiddleware
 
 # TODO: Disable OpenAPI by default
 class BaseAPI(FastAPI):
-    def __init__(self, *args, settings: Optional[BaseSettings] = None, **extra):
+    def __init__(self, nlp=None, dialogue_manager=None, settings: Optional[BaseSettings] = None, **kwargs):
         self.settings = settings or SkillSettings()
-        middleware = extra.get('middlewares', [])
+        middleware = kwargs.pop('middlewares', [])
+
+        self.nlp = nlp
+        self.dialogue_manager = dialogue_manager
 
         if self.settings.use_encryption:
             private_key = load_private_key(self.settings.private_key_path.read_bytes())
@@ -27,7 +30,7 @@ class BaseAPI(FastAPI):
                 *middleware,
             ]
 
-        super().__init__(*args, **extra, middleware=middleware)
+        super().__init__(**kwargs, middleware=middleware)
         self.router.add_api_route('/parse', self.parse, methods=['POST'], response_model=SkillInvokeResponse)
 
     async def parse(self, request: SkillInvokeRequest):

--- a/webex_assistant_sdk/api/mindmeld.py
+++ b/webex_assistant_sdk/api/mindmeld.py
@@ -1,6 +1,6 @@
 import warnings
 
-from ..dialogue.manager import MMDialogueManager
+from ..dialogue.manager import NLPDialogueManager
 from ..models.http import SkillInvokeRequest, SkillInvokeResponse
 from ..models.mindmeld import DialogueState, ProcessedQuery
 from .base import BaseAPI
@@ -22,16 +22,19 @@ class suppress_warnings:
         return
 
 
-with suppress_warnings():
-    from mindmeld import NaturalLanguageProcessor
-
-
 class MindmeldAPI(BaseAPI):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.nlp = NaturalLanguageProcessor(self.settings.app_dir)
-        self.nlp.load()
-        self.dialogue_manager = MMDialogueManager()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        if not self.nlp:
+            with suppress_warnings():
+                from mindmeld import NaturalLanguageProcessor
+
+                self.nlp = NaturalLanguageProcessor(self.settings.app_dir)
+                self.nlp.load()
+
+        if not self.dialogue_manager:
+            self.dialogue_manager = NLPDialogueManager()
 
     async def parse(self, request: SkillInvokeRequest):
         current_state = DialogueState(**request.dict())

--- a/webex_assistant_sdk/api/simple.py
+++ b/webex_assistant_sdk/api/simple.py
@@ -9,10 +9,10 @@ from webex_assistant_sdk.models.mindmeld import DialogueState
 
 
 class SimpleAPI(BaseAPI):
-    def __init__(self, *args, dialogue_manager=None, **extra: Any) -> None:
-        super().__init__(*args, **extra)
-        self.skill_name = self.settings.skill_name
-        self.dialogue_manager = dialogue_manager or SimpleDialogueManager()
+    def __init__(self, **extra: Any) -> None:
+        super().__init__(**extra)
+        if not self.dialogue_manager:
+            self.dialogue_manager = SimpleDialogueManager()
 
     async def parse(self, request: SkillInvokeRequest) -> SkillInvokeResponse:
         current_state = DialogueState(**request.dict())


### PR DESCRIPTION
We would eventually like to support custom NLP or Dialogue Manager implementations,
this is an initial step in that direction. Additionally, this will allow us to inject test NLP
and dialogue manager instances for testing the API.