### PR TITLE
Update dialogue history after each request, sort mindmeld rules.

### DIFF
--- a/webex_assistant_sdk/api/simple.py
+++ b/webex_assistant_sdk/api/simple.py
@@ -5,8 +5,6 @@ from webex_assistant_sdk.dialogue.manager import SimpleDialogueManager
 from webex_assistant_sdk.models.http import SkillInvokeRequest, SkillInvokeResponse
 from webex_assistant_sdk.models.mindmeld import DialogueState
 
-# TODO: Update history
-
 
 class SimpleAPI(BaseAPI):
     def __init__(self, **extra: Any) -> None:
@@ -16,7 +14,7 @@ class SimpleAPI(BaseAPI):
 
     async def parse(self, request: SkillInvokeRequest) -> SkillInvokeResponse:
         current_state = DialogueState(**request.dict())
-        new_state = await self.dialogue_manager.handle(current_state)
+        new_state = await self.dialogue_manager.handle(query=current_state.text, current_state=current_state)
         response = SkillInvokeResponse(**new_state.dict(), challenge=request.challenge)
         return response
 

--- a/webex_assistant_sdk/dialogue/manager.py
+++ b/webex_assistant_sdk/dialogue/manager.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union, cast
 
 from ..models.mindmeld import DialogueState, ProcessedQuery
 from ..types import DialogueHandler
@@ -10,36 +10,41 @@ class MissingHandler(Exception):
     pass
 
 
-RuleMap = Dict[SimpleDialogueStateRule, DialogueHandler]
+DialogueRule = Union[SimpleDialogueStateRule, MMDialogueStateRule]
+RuleMap = Dict[DialogueRule, DialogueHandler]
+
+DialogueQuery = Union[ProcessedQuery, str]
 
 
-class MMDialogueManager:
-    def __init__(self, rules=None, default_handler=None):
+class DialogueManager:
+    def __init__(self, rules: Optional[RuleMap] = None, default_handler: Optional[DialogueHandler] = None):
         self.rules = rules or {}
         self.default_handler = default_handler
 
-    async def handle(self, processed_query, current_state):
-        # Iterate over our rules, taking the first match
-        handler = self.get_dialogue_state(processed_query, current_state.params.target_dialogue_state)
-        handler = handler or self.default_handler
-
-        if not handler:
-            raise MissingHandler('No handler found')
-
-        return await handler(current_state)
-
-    def get_dialogue_state(
-        self, query: ProcessedQuery, dialogue_state: Optional[str] = None
-    ) -> Optional[DialogueHandler]:
-        # TODO: this needs to iterate over a sorted list of rules by specificity to determine
-        # which rule matches.
+    def get_dialogue_state(self, query: DialogueQuery, target_state: Optional[str] = None) -> Optional[DialogueHandler]:
         for rule, handler in self.rules.items():
-            if dialogue_state and rule.dialogue_state == dialogue_state:
+            if target_state and rule.dialogue_state == target_state:
                 return handler
-            if not dialogue_state and rule.match(query):
+            if not target_state and rule.match(query):
                 return handler
         return None
 
+    async def handle(self, query: DialogueQuery, current_state: DialogueState):
+        # Iterate over our rules, taking the first match
+        handler = self.get_dialogue_state(query, current_state.params.target_dialogue_state)
+        handler = handler or self.default_handler
+
+        if not handler:
+            # TODO: Different message
+            raise MissingHandler('No handler found')
+
+        new_state = await handler(current_state)
+        new_state.update_history(old_state=current_state)
+        return new_state
+
+
+# TODO: Sort rules by specificity prior to get_dialogue_state
+class MMDialogueManager(DialogueManager):
     def add_rule(
         self,
         *,
@@ -60,36 +65,15 @@ class MMDialogueManager:
             rule_name = name or handler.__name__.lower()
             skill_rule = MMDialogueStateRule(domain, intent, entities, rule_name, targeted_only=targeted_only)
             self.rules[skill_rule] = handler
+            existing_rules: List[(MMDialogueStateRule, DialogueHandler)] = list(self.rules.items())
+            self.rules = dict(sorted(existing_rules, reverse=True))
 
             return handler
 
         return decorator
 
 
-class SimpleDialogueManager:
-    def __init__(self, rules: Optional[RuleMap] = None, default_handler: Optional[DialogueHandler] = None):
-        self.rules = rules or {}
-        self.default_handler = default_handler
-
-    async def handle(self, current_state: DialogueState):
-        # Iterate over our rules, taking the first match
-        handler = self.get_dialogue_state(current_state.text, current_state.params.target_dialogue_state)
-        handler = handler or self.default_handler
-
-        if not handler:
-            # TODO: Different message
-            raise MissingHandler('No handler found')
-
-        return await handler(current_state)
-
-    def get_dialogue_state(self, query: str, target_state: Optional[str] = None) -> Optional[DialogueHandler]:
-        for rule, handler in self.rules.items():
-            if target_state and rule.dialogue_state == target_state:
-                return handler
-            if not target_state and rule.match(query):
-                return handler
-        return None
-
+class SimpleDialogueManager(DialogueManager):
     def add_rule(
         self, *, name: Optional[str] = None, pattern: Optional[str] = None, default=False, targeted_only=False
     ):

--- a/webex_assistant_sdk/dialogue/rules.py
+++ b/webex_assistant_sdk/dialogue/rules.py
@@ -10,6 +10,10 @@ class MMDialogueStateRule:
     def __init__(self, domain, intent, entities, dialogue_state, targeted_only):
         self.domain = domain
         self.intent = intent
+
+        if entities:
+            entities = set(entities)
+
         self.entities = entities
         self.targeted_only = targeted_only
         self.dialogue_state = dialogue_state

--- a/webex_assistant_sdk/models/mindmeld.py
+++ b/webex_assistant_sdk/models/mindmeld.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, ForwardRef, List, Optional
 
 from pydantic import BaseModel, constr
 
@@ -29,12 +29,22 @@ class ProcessedQuery(BaseModel):
     entities: Optional[List[Dict[Any, Any]]]
 
 
+DialogueState = ForwardRef('DialogueState')
+
+
 class DialogueState(BaseModel):
     text: Optional[str]
     context: Dict[Any, Any]
     params: Params
     frame: Dict[Any, Any]
-    history: Optional[List[Dict[Any, Any]]] = []
+    history: Optional[List[DialogueState]] = []
     # TODO: Unsure if I should put this directly on the State object or if our method should just be required
     # to return a state and a list of directives
     directives: Optional[List[Dict[Any, Any]]] = []
+
+    def update_history(self, old_state: DialogueState):
+        old_state_dict = DialogueState(**old_state.dict(exclude={'history'}))
+        self.history.append(old_state_dict)
+
+
+DialogueState.update_forward_refs()


### PR DESCRIPTION
This adds an update_history method to our DialogueState model and moves some common dialogue
management functionality (such as updating that history) to a new base class. Additionally, the mindmeld
rules are now sorted after each addition so the most specific rules are checked first.