### PR TITLE
Fixes a couple dialogue manager bugs

### DIFF
--- a/webex_assistant_sdk/api/mindmeld.py
+++ b/webex_assistant_sdk/api/mindmeld.py
@@ -42,6 +42,6 @@ class MindmeldAPI(BaseAPI):
         response = SkillInvokeResponse(**new_state.dict(), challenge=request.challenge)
         return response
 
-    def handle(self, *, domain=None, intent=None, entities=None):
+    def handle(self, *, domain=None, intent=None, entities=None, default=False):
         """Wraps a function to behave as a dialogue handler"""
-        return self.dialogue_manager.add_rule(domain=domain, intent=intent, entities=entities)
+        return self.dialogue_manager.add_rule(domain=domain, intent=intent, entities=entities, default=default)

--- a/webex_assistant_sdk/dialogue/manager.py
+++ b/webex_assistant_sdk/dialogue/manager.py
@@ -1,8 +1,9 @@
+import inspect
 import re
-from typing import Dict, List, Optional, Union, cast
+from typing import List, Optional
 
-from ..models.mindmeld import DialogueState, ProcessedQuery
-from ..types import DialogueHandler
+from ..models.mindmeld import DialogueState
+from ..types import DialogueHandler, DialogueQuery, RuleMap
 from .rules import MMDialogueStateRule, SimpleDialogueStateRule
 
 
@@ -10,18 +11,12 @@ class MissingHandler(Exception):
     pass
 
 
-DialogueRule = Union[SimpleDialogueStateRule, MMDialogueStateRule]
-RuleMap = Dict[DialogueRule, DialogueHandler]
-
-DialogueQuery = Union[ProcessedQuery, str]
-
-
 class DialogueManager:
     def __init__(self, rules: Optional[RuleMap] = None, default_handler: Optional[DialogueHandler] = None):
         self.rules = rules or {}
         self.default_handler = default_handler
 
-    def get_dialogue_state(self, query: DialogueQuery, target_state: Optional[str] = None) -> Optional[DialogueHandler]:
+    def get_handler(self, query: DialogueQuery, target_state: Optional[str] = None) -> Optional[DialogueHandler]:
         for rule, handler in self.rules.items():
             if target_state and rule.dialogue_state == target_state:
                 return handler
@@ -31,19 +26,23 @@ class DialogueManager:
 
     async def handle(self, query: DialogueQuery, current_state: DialogueState):
         # Iterate over our rules, taking the first match
-        handler = self.get_dialogue_state(query, current_state.params.target_dialogue_state)
+        handler = self.get_handler(query, current_state.params.target_dialogue_state)
         handler = handler or self.default_handler
 
         if not handler:
             # TODO: Different message
             raise MissingHandler('No handler found')
 
-        new_state = await handler(current_state)
+        # TODO: Use annotated types rather than length
+        handler_args = inspect.signature(handler)
+        if len(handler_args.parameters) == 2:
+            new_state = await handler(current_state, query)
+        else:
+            new_state = await handler(current_state)
         new_state.update_history(old_state=current_state)
         return new_state
 
 
-# TODO: Sort rules by specificity prior to get_dialogue_state
 class MMDialogueManager(DialogueManager):
     def add_rule(
         self,

--- a/webex_assistant_sdk/types.py
+++ b/webex_assistant_sdk/types.py
@@ -1,5 +1,13 @@
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Dict, Union
 
-from webex_assistant_sdk.models.mindmeld import DialogueState
+from webex_assistant_sdk.dialogue.rules import MMDialogueStateRule, SimpleDialogueStateRule
+from webex_assistant_sdk.models.mindmeld import DialogueState, ProcessedQuery
 
-DialogueHandler = Callable[[DialogueState], Awaitable[DialogueState]]
+DialogueQuery = Union[ProcessedQuery, str]
+SimpleHandler = Callable[[DialogueState], Awaitable[DialogueState]]
+QueryHandler = Callable[[DialogueState, DialogueQuery], Awaitable[DialogueState]]
+
+DialogueHandler = Union[SimpleHandler, QueryHandler]
+DialogueRule = Union[SimpleDialogueStateRule, MMDialogueStateRule]
+
+RuleMap = Dict[DialogueRule, DialogueHandler]


### PR DESCRIPTION
The mindmeld API was missing support for a default handler, that argument has now been added. Additionally, the
dialogue manager was originally intended to pass the entities into queries which used entities, which was missed.
Instead, now if the handler specifies a second argument, the entire query object (either a processed query or a string)
is passed as a second argument.