### PR TITLE
Add uvicorn as a dependency, cleanup imports.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -21,7 +21,7 @@ speedups = ["aiodns", "brotlipy", "cchardet"]
 name = "asgiref"
 version = "3.4.1"
 description = "ASGI specs, helper code, and adapters"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -351,7 +351,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "h11"
 version = "0.12.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1094,7 +1094,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 name = "uvicorn"
 version = "0.15.0"
 description = "The lightning-fast ASGI server."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1179,7 +1179,7 @@ mindmeld = ["mindmeld"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9e88f5c779474003b379486aed11c6aa2d854fa2e55b30b77ba28518887cd2ec"
+content-hash = "a5f37896d4a28717e3e5ea4249cbaf4d43cc5d651cff1d5b04b2ed5ddfb261be"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ requests = "^2.22.0"
 typer = "^0.4.0"
 pydantic = {extras = ["dotenv"], version = "^1.8.2"}
 fastapi = "^0.68.1"
+uvicorn = "^0.15.0"
 
 [tool.poetry.dev-dependencies]
 black = '^21.9b0'
@@ -40,7 +41,6 @@ tox = "^3.14.0"
 autopep8 = "^1.5.7"
 mock = "^4.0.3"
 pytest-asyncio = "^0.15.1"
-uvicorn = "^0.15.0"
 
 [tool.poetry.extras]
 mindmeld = ["mindmeld"]

--- a/webex_skills/cli/skill.py
+++ b/webex_skills/cli/skill.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import json
 from json import JSONDecodeError
-import locale
 import os
 from pathlib import Path
 from pprint import pformat


### PR DESCRIPTION
uvicorn was originally listed as a dev dependency, however given its usefulness in the initial developer experience we've
decided to make it a proper dependency rather than an extra. We're trying to strike a balance between developer convenience
and package bloat and for the time being at least we've decided to lean toward the former.