### PR TITLE
Split get_skill_config into more specific functions.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-
 from webex_skills.dialogue.rules import SimpleDialogueStateRule
 from webex_skills.models.mindmeld import DialogueState
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2,7 +2,6 @@ import base64
 import json
 
 import pytest
-
 from webex_skills.crypto import sign_token, verify_signature
 
 

--- a/tests/test_dialogue.py
+++ b/tests/test_dialogue.py
@@ -1,5 +1,4 @@
 import pytest
-
 from webex_skills.dialogue.manager import SimpleDialogueManager
 
 pytestmark = pytest.mark.asyncio

--- a/webex_skills/cli/config.py
+++ b/webex_skills/cli/config.py
@@ -17,17 +17,8 @@ def get_remotes():
     """Returns configuration for all named skills"""
     if not CONFIG_FILE.exists():
         return {}
-    config = load_config()
+    config = json.loads(CONFIG_FILE.read_text(encoding='utf-8'))
     return config.get('remotes', {})
-
-
-def load_config():
-    """Attempts to load the configuration file"""
-    try:
-        return json.loads(CONFIG_FILE.read_text(encoding='utf-8')) or {}
-    except json.JSONDecodeError:
-        typer.secho('Invalid JSON in configuration file', color=typer.colors.RED, err=True)
-        raise typer.Exit(1)
 
 
 def get_app_dir(name: str):

--- a/webex_skills/cli/nlp.py
+++ b/webex_skills/cli/nlp.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import typer
 
-from .config import get_skill_config
+from .config import get_app_dir
 from .helpers import create_nlp
 
 app = typer.Typer(help='Commands for working with NLP models')
@@ -11,34 +11,22 @@ app = typer.Typer(help='Commands for working with NLP models')
 
 # take name to find app path, otherwise default to cwd
 @app.command()
-def build(
-    name: Optional[str] = typer.Argument(
-        None,
-        help="The name of the skill to build.",
-    ),
-):
+def build(name: Optional[str] = typer.Argument(None, help="The name of the skill to build.")):
     """Build nlp models associated with this skill"""
     app_dir = '.'
     if name:
-        config = get_skill_config(name)
-        app_dir = config['app_dir']
+        app_dir = get_app_dir(name)
 
     nlp = create_nlp(app_dir)
     nlp.build()
 
 
 @app.command()
-def process(
-    name: Optional[str] = typer.Argument(
-        None,
-        help="The name of the skill to send the query to.",
-    ),
-):
+def process(name: Optional[str] = typer.Argument(None, help="The name of the skill to send the query to.")):
     """Run a query through NLP processing"""
     app_dir = '.'
     if name:
-        config = get_skill_config(name)
-        app_dir = config['app_dir']
+        app_dir = get_app_dir(name)
 
     nlp = create_nlp(app_dir)
     nlp.load()

--- a/webex_skills/cli/remote.py
+++ b/webex_skills/cli/remote.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import typer
 
-from .config import get_skill_config
+from .config import get_remotes
 
 remote = typer.Typer(name='remote', help='Commands for interacting with running skills')
 
@@ -81,7 +81,7 @@ def ls(
     name: Optional[str] = typer.Option(None, help="The name of a particular skill to display.")
 ):  # pylint:disable=invalid-name
     """List configured remote skills"""
-    remotes = get_skill_config()
+    remotes = get_remotes()
     if not remotes:
         typer.secho('No configured remotes found', color=typer.colors.RED, err=True)
         raise typer.Exit(1)


### PR DESCRIPTION
The get_skill_config method previously attempted to handle a number of cases such as when config
doesn't exist, getting a config for specific skill, or getting all skill configurations. This resulted
in the introduction of a bug in PR #50 where the init command attempted to determine if a skill with the
passed in name already existed. The get_skill_config method would make an empty default configuration
if one didn't exist, but seeing a name passed in would then attempt to read from that empty value and
throw an error. This resulted in a new user being unable to initialize a project. To hopefully avoid
other issues in the future the 4 functions previously contained in the get_skill_config method have
been split into their own smaller methods which the commands can make use of as needed.