### PR TITLE
Use a fixed context in the `invoke` cli command.

### DIFF
--- a/webex_skills/cli/skill.py
+++ b/webex_skills/cli/skill.py
@@ -98,7 +98,7 @@ def invoke_skill(
     }
 
     req = {
-        'challenge': (os.urandom(32).hex()),
+        'challenge': os.urandom(32).hex(),
         'text': query,
         'context': default_context,
         'params': default_params,

--- a/webex_skills/cli/skill.py
+++ b/webex_skills/cli/skill.py
@@ -91,14 +91,17 @@ def invoke_skill(
         'timestamp': datetime.utcnow().timestamp(),
         'language': 'en',
     }
+
+    default_context = {
+        'userId': user_id,
+        'orgId': org_id,
+        'developerDeviceId': device_id,
+    }
+
     message = {
         'challenge': challenge,
         'text': query,
-        'context': {
-            'userId': user_id,
-            'orgId': org_id,
-            'developerDeviceId': device_id,
-        },
+        'context': default_context,
         'params': default_params,
         'frame': {},
         'history': [],
@@ -133,7 +136,7 @@ def invoke_skill(
         message = {
             'challenge': challenge,
             'text': query,
-            'context': json_resp.get('context', {}),
+            'context': default_context,
             'params': json_resp.get('params', default_params),
             'frame': json_resp.get('frame', []),
             'history': json_resp.get('history', []),


### PR DESCRIPTION
Context is immutable and is not able to be changed by the skill. The
invoke command in the CLI however expected that on turns after the first
the context would be provided by the skill response. This led to the
context working on the first request but being empty on all subsequent requests. 
The context is now set to a default value before calling a skill
and the requests reuse the same context value until exit.