### PR TITLE
Fix bug introduced by linting cleanup related to encrypted payloads.

### DIFF
--- a/webex_skills/cli/skill.py
+++ b/webex_skills/cli/skill.py
@@ -97,8 +97,9 @@ def invoke_skill(
         'developerDeviceId': device_id,
     }
 
+    challenge = os.urandom(32).hex()
     req = {
-        'challenge': os.urandom(32).hex(),
+        'challenge': challenge,
         'text': query,
         'context': default_context,
         'params': default_params,
@@ -124,14 +125,15 @@ def invoke_skill(
             typer.secho('Unable to deserialize JSON response')
             json_resp = {}
 
-        if not json_resp.get('challenge') == req['challenge']:
+        if not json_resp.get('challenge') == challenge:
             typer.secho('Skill did not respond with expected challenge value', fg=typer.colors.RED, err=True)
 
         typer.secho(pformat(json_resp, indent=2, width=120), fg=typer.colors.GREEN)
         query = typer.prompt('>>', prompt_suffix=' ')
 
+        challenge = os.urandom(32).hex()
         req = {
-            'challenge': os.urandom(32).hex(),
+            'challenge': challenge,
             'text': query,
             'context': default_context,
             'params': json_resp.get('params', default_params),


### PR DESCRIPTION
Previously the challenge value of an invoke request payload was inlined into the request
body and the request's challenge field was compared against the response. This however
was not possible when the payload was encrypted and led to a KeyError trying to access it.
The challenge value has been moved into its own variable for comparison in both encrypted
and non-encrypted payloads. This is a temporary fix while we rework the cli portion
dealing with invoking/running skills is reworked to be more flexible.