### PR TITLE
Fixes a missing option in the `handle` method of `MindmeldAPI`

### DIFF
--- a/webex_skills/api/mindmeld.py
+++ b/webex_skills/api/mindmeld.py
@@ -42,9 +42,10 @@ class MindmeldAPI(BaseAPI):
         response = SkillInvokeResponse(**new_state.dict(), challenge=request.challenge)
         return response
 
-    def handle(self, *, domain=None, intent=None, entities=None, default=False, targeted_only=False):
+    def handle(self, *, name=None, domain=None, intent=None, entities=None, default=False, targeted_only=False):
         """Wraps a function to behave as a dialogue handler"""
         return self.dialogue_manager.add_rule(
+            name=name,
             domain=domain,
             intent=intent,
             entities=entities,


### PR DESCRIPTION
The handle method did not previously allow for specifying a name argument.
This adds an option for name, and passes it along to the `add_rule` method
as it should have initially.