### PR TITLE
feat(cli): add host and port options to run command

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+from typer.testing import CliRunner
+from webex_skills.cli.skill import app
+
+runner = CliRunner()
+
+
+def test_cli_run_custom_host_and_port():
+    fake_config = {
+        'project_path': '/tmp/fake',
+        'private_key_path': '/tmp/fake.key',
+        'secret': 'secret',
+        'app_dir': '/tmp/app',
+    }
+
+    with (
+        patch('webex_skills.cli.skill.get_skill_config', return_value=fake_config),
+        patch('webex_skills.cli.skill.uvicorn.run') as mock_uvicorn,
+    ):
+        result = runner.invoke(app, ['run', 'my_skill', '--host', '0.0.0.0', '--port', '9090'])
+        assert result.exit_code == 0
+        mock_uvicorn.assert_called_once_with('my_skill.main:api', host='0.0.0.0', port=9090, log_level='info')

--- a/webex_skills/cli/skill.py
+++ b/webex_skills/cli/skill.py
@@ -143,13 +143,17 @@ def invoke_skill(
 
 
 @app.command()
-def run(skill_name: str = typer.Argument(..., help="The name of the skill to run.")):
+def run(
+    skill_name: str = typer.Argument(..., help="The name of the skill to run."),
+    host: str = typer.Option("127.0.0.1", "--host", "-h", help="The host interface to bind the server to."),
+    port: int = typer.Option(8080, "--port", "-p", help="The port to bind the server to."),
+):
     config = get_skill_config(skill_name)
     sys.path.insert(0, config['project_path'])
     os.environ['SKILLS_PRIVATE_KEY_PATH'] = config['private_key_path']
     os.environ['SKILLS_SECRET'] = config['secret']
     os.environ['SKILLS_APP_DIR'] = config['app_dir']
-    uvicorn.run(f'{skill_name}.main:api', host="127.0.0.1", port=8080, log_level="info")
+    uvicorn.run(f'{skill_name}.main:api', host=host, port=port, log_level="info")
 
 
 @app.command()


### PR DESCRIPTION
Fixes #57

Added `--host` (`-h`) and `--port` (`-p`) options to `webex-skills run` CLI command so devs can specify a custom interface and port instead of being stuck on `127.0.0.1:8080`.

Added unit tests in `tests/test_cli.py` to verify custom host and port parameters.